### PR TITLE
Added compatibility for Lootr.

### DIFF
--- a/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/MineshaftPiece.java
+++ b/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/MineshaftPiece.java
@@ -9,6 +9,7 @@ import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.BarrelTileEntity;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.RegistryKey;
@@ -129,10 +130,7 @@ public abstract class MineshaftPiece extends StructurePiece {
     protected void addBarrel(ISeedReader world, MutableBoundingBox boundingBox, Random random, BlockPos pos, ResourceLocation lootTableId) {
         if (boundingBox.isVecInside(pos) && world.getBlockState(pos).getBlock() != Blocks.BARREL) {
             world.setBlockState(pos, Blocks.BARREL.getDefaultState().with(BarrelBlock.PROPERTY_FACING, Direction.UP), 2);
-            TileEntity blockEntity = world.getTileEntity(pos);
-            if (blockEntity instanceof BarrelTileEntity) {
-                ((BarrelTileEntity) blockEntity).setLootTable(lootTableId, random.nextLong());
-            }
+            LockableLootTileEntity.setLootTable(world, random, pos, lootTableId);
         }
     }
 


### PR DESCRIPTION
Lootr provides instanced inventories for all chests & barrels that have an associated loot table. Each time a player opens a chest for the first time, a new inventory is generated & populated.

This results in less stress on multiplayer servers as people are less likely to explore long distances because "all the structures have been looted".

The static LockableLootTileEntity.setLootTable is a hook that has the correct worldgen reader/writer passed in to it, whereas unfortunately it's impossible to hook off the non-static method.

Otherwise, the functionality is identical, and, if anything, duplicated by not using the static method.