### PR TITLE
Improved property finding for modded blocks in variants.json

### DIFF
--- a/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/json/BlockStateAdapter.java
+++ b/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/json/BlockStateAdapter.java
@@ -108,32 +108,31 @@ public class BlockStateAdapter extends TypeAdapter<IBlockState> {
                 while (blockClass != Block.class && !found) {
                     Field[] fields = blockClass.getDeclaredFields();
                     for (Field field : fields) {
+                        if (!IProperty.class.isAssignableFrom(field.getType())) {
+                            continue;
+                        }
                         field.setAccessible(true);
-                        Object _field;
+                        IProperty<T> property;
                         try {
-                            _field = field.get(blockState);
+                            property = (IProperty<T>) field.get(blockState);
                         } catch (Exception e) {
                             try {
-                                _field = field.get(blockState.getBlock());
+                                property = (IProperty<T>) field.get(blockState.getBlock());
                             } catch (Exception ignored) {
                                 continue;
                             }
                         }
 
-                        if (_field instanceof IProperty) {
-                            IProperty<T> property = (IProperty<T>) _field;
-
-                            if (property.getName().equals(key)) {
-                                Object val = property.parseValue(value).orNull();
-                                Class<T> blockEnumClass = property.getValueClass();
-                                try {
-                                    blockState = blockState.withProperty(property, Objects.requireNonNull(blockEnumClass.cast(val)));
-                                } catch (Exception e) {
-                                    continue;
-                                }
-                                found = true;
-                                break;
+                        if (property.getName().equals(key)) {
+                            Object val = property.parseValue(value).orNull();
+                            Class<T> blockEnumClass = property.getValueClass();
+                            try {
+                                blockState = blockState.withProperty(property, Objects.requireNonNull(blockEnumClass.cast(val)));
+                            } catch (Exception e) {
+                                continue;
                             }
+                            found = true;
+                            break;
                         }
                     }
                     blockClass = blockClass.getSuperclass();


### PR DESCRIPTION
`BlockStateAdapter#getConfiguredBlockState` now only tries to get fields that implement `Property<T>`, instead of checking the object's type after getting it.

This also fixes a really weird bug that causes a segmentation fault (somehow) when running RLCraft on Cleanroom loader.
I have attached the crash log below.

[hs_err_pid15444.log](https://github.com/user-attachments/files/18874514/hs_err_pid15444.log)
