### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -16,15 +16,12 @@ neoForge {
 
 dependencies {
     compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.5'
+    compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.5.3'
     if (useLocalYungsApi) {
         compileOnly files("libs/YungsApi-${mc_version}-Common-${yungsapi_version}.jar")
     } else {
         compileOnly("com.yungnickyoung.minecraft.yungsapi:YungsApi:${mc_version}-Common-${yungsapi_version}")
     }
-
-    // fabric and neoforge both bundle mixinextras, so it is safe to use it in common
-    compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.5.3'
-    annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.5.3'
 }
 
 configurations {

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BetterMineshaftPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BetterMineshaftPiece.java
@@ -11,6 +11,7 @@ import net.minecraft.data.worldgen.features.CaveFeatures;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.WorldGenLevel;
@@ -224,7 +225,7 @@ public abstract class BetterMineshaftPiece extends StructurePiece {
 
                     // Dead bushes
                     if (config.decorationChances.deadBushChance > 0 && randomSource.nextFloat() < config.decorationChances.deadBushChance) {
-                        if (state.isAir() && (stateBelow.is(Blocks.SAND) || stateBelow.is(Blocks.RED_SAND) || stateBelow.is(Blocks.TERRACOTTA) || stateBelow.is(Blocks.WHITE_TERRACOTTA) || stateBelow.is(Blocks.ORANGE_TERRACOTTA) || stateBelow.is(Blocks.YELLOW_TERRACOTTA) || stateBelow.is(Blocks.BROWN_TERRACOTTA) || stateBelow.is(Blocks.DIRT))) {
+                        if (state.isAir() && (stateBelow.is(Blocks.SAND) || stateBelow.is(Blocks.RED_SAND) || stateBelow.is(Blocks.TERRACOTTA) || stateBelow.is(Blocks.DYED_TERRACOTTA.pick(DyeColor.WHITE)) || stateBelow.is(Blocks.DYED_TERRACOTTA.pick(DyeColor.ORANGE)) || stateBelow.is(Blocks.DYED_TERRACOTTA.pick(DyeColor.YELLOW)) || stateBelow.is(Blocks.DYED_TERRACOTTA.pick(DyeColor.BROWN)) || stateBelow.is(Blocks.DIRT))) {
                             this.placeBlock(world, Blocks.DEAD_BUSH.defaultBlockState(), x, y, z, box);
                         }
                     }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BigTunnel.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BigTunnel.java
@@ -11,9 +11,12 @@ import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandom
 import com.yungnickyoung.minecraft.yungsapi.world.util.BoundingBoxHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.*;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntitySpawnRequest;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.vehicle.minecart.MinecartChest;
 import net.minecraft.world.entity.vehicle.minecart.MinecartTNT;
@@ -402,7 +405,7 @@ public class BigTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.mainShaftChestMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartChest chestMinecartEntity = EntityType.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartChest chestMinecartEntity = (MinecartChest) BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "chest_minecart")).create(world.getLevel(), new EntitySpawnRequest(EntitySpawnReason.STRUCTURE, false));
                     if (chestMinecartEntity != null) {
                         chestMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         chestMinecartEntity.setLootTable(BuiltInLootTables.ABANDONED_MINESHAFT, randomSource.nextLong());
@@ -418,7 +421,7 @@ public class BigTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.mainShaftTntMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartTNT tntMinecartEntity = EntityType.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartTNT tntMinecartEntity = (MinecartTNT) BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "tnt_minecart")).create(world.getLevel(), new EntitySpawnRequest(EntitySpawnReason.STRUCTURE, false));
                     if (tntMinecartEntity != null) {
                         tntMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         world.addFreshEntity(tntMinecartEntity);

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SideRoomDungeon.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SideRoomDungeon.java
@@ -5,7 +5,9 @@ import com.yungnickyoung.minecraft.bettermineshafts.world.config.BetterMineshaft
 import com.yungnickyoung.minecraft.bettermineshafts.module.StructurePieceTypeModule;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.ChunkPos;
@@ -102,7 +104,7 @@ public class SideRoomDungeon extends BetterMineshaftPiece {
         world.setBlock(spawnerPos, Blocks.SPAWNER.defaultBlockState(), 2);
         BlockEntity blockEntity = world.getBlockEntity(spawnerPos);
         if (blockEntity instanceof SpawnerBlockEntity) {
-            ((SpawnerBlockEntity) blockEntity).setEntityId(EntityType.CAVE_SPIDER, randomSource);
+            ((SpawnerBlockEntity) blockEntity).setEntityId(BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "cave_spider")), randomSource);
         }
 
         // Cobwebs immediately surrounding chests

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SmallTunnel.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SmallTunnel.java
@@ -8,13 +8,15 @@ import com.yungnickyoung.minecraft.bettermineshafts.world.generator.BetterMinesh
 import com.yungnickyoung.minecraft.yungsapi.world.util.BoundingBoxHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntitySpawnRequest;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.vehicle.minecart.MinecartChest;
 import net.minecraft.world.entity.vehicle.minecart.MinecartChest;
 import net.minecraft.world.entity.vehicle.minecart.MinecartTNT;
 import net.minecraft.world.level.ChunkPos;
@@ -134,7 +136,7 @@ public class SmallTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.smallShaftChestMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartChest chestMinecartEntity = EntityType.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartChest chestMinecartEntity = (MinecartChest) BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "chest_minecart")).create(world.getLevel(), new EntitySpawnRequest(EntitySpawnReason.STRUCTURE, false));
                     if (chestMinecartEntity != null) {
                         chestMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         chestMinecartEntity.setLootTable(BuiltInLootTables.ABANDONED_MINESHAFT, randomSource.nextLong());
@@ -199,7 +201,7 @@ public class SmallTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.smallShaftTntMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartTNT tntMinecartEntity = EntityType.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartTNT tntMinecartEntity = (MinecartTNT) BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "tnt_minecart")).create(world.getLevel(), new EntitySpawnRequest(EntitySpawnReason.STRUCTURE, false));
                     if (tntMinecartEntity != null) {
                         tntMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         world.addFreshEntity(tntMinecartEntity);

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/ZombieVillagerRoom.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/ZombieVillagerRoom.java
@@ -5,9 +5,14 @@ import com.yungnickyoung.minecraft.bettermineshafts.module.StructurePieceTypeMod
 import com.yungnickyoung.minecraft.yungsapi.world.util.BoundingBoxHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntitySpawnRequest;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.StructureManager;
 import net.minecraft.world.level.WorldGenLevel;
@@ -130,17 +135,17 @@ public class ZombieVillagerRoom extends BetterMineshaftPiece {
         this.fill(world, box, 6, 2, 2, 6, 2, 4, Blocks.IRON_BARS.defaultBlockState());
 
         // Beds
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 1, 1, 4, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 1, 1, 5, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 5, 1, 4, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 5, 1, 5, box);
+        this.placeBlock(world, Blocks.BED.pick(DyeColor.BLACK).defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 1, 1, 4, box);
+        this.placeBlock(world, Blocks.BED.pick(DyeColor.BLACK).defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 1, 1, 5, box);
+        this.placeBlock(world, Blocks.BED.pick(DyeColor.BLACK).defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 5, 1, 4, box);
+        this.placeBlock(world, Blocks.BED.pick(DyeColor.BLACK).defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 5, 1, 5, box);
 
         // Mob spawner
         BlockPos spawnerPos = this.getWorldPos(3, 0, 3);
         world.setBlock(spawnerPos, Blocks.SPAWNER.defaultBlockState(), 2);
         BlockEntity blockEntity = world.getBlockEntity(spawnerPos);
         if (blockEntity instanceof SpawnerBlockEntity) {
-            ((SpawnerBlockEntity) blockEntity).setEntityId(EntityType.ZOMBIE_VILLAGER, randomSource);
+            ((SpawnerBlockEntity) blockEntity).setEntityId(BuiltInRegistries.ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("minecraft", "zombie_villager")), randomSource);
         }
 
         // Wall with redstone torch in corner

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=The long-awaited and much-needed abandoned mineshaft overhaul!
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.bettermineshafts
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=373591
 curseforge_project_id_neoforge=389665
 modrinth_project_id=HjmxVlSr
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.156.0
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.0
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.37-beta
+neoforge_version_range=[26.2.0.37-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates all build properties and source code to compile against Minecraft 26.2.

Changes:
- Bump `mc_version`, `fabric_version`, `fabric_loader_version`, `clothconfig`, `modmenu`, NeoForge deps
- `StructureProcessor` is now an interface (extends → implements)
- `CriterionTrigger` moved to `net.minecraft.advancements.triggers`
- Block color variants → `ColorCollection.pick(DyeColor)`
- `EntityType` static fields → `BuiltInRegistries.ENTITY_TYPE` lookups
- `EntitySpawnReason` → `EntitySpawnRequest` wrapper
- `Identifier.of` → `Identifier.fromNamespaceAndPath`
- `StructureProcessorType` no longer generic
- `markPosForPostprocessing` → `markPosForPostProcessing`

Tested: Fabric build compiles and runs on MC 26.2 server.