### PR TITLE
Port to Minecraft 26.2

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BetterMineshaftPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BetterMineshaftPiece.java
@@ -224,7 +224,7 @@ public abstract class BetterMineshaftPiece extends StructurePiece {
 
                     // Dead bushes
                     if (config.decorationChances.deadBushChance > 0 && randomSource.nextFloat() < config.decorationChances.deadBushChance) {
-                        if (state.isAir() && (stateBelow.is(Blocks.SAND) || stateBelow.is(Blocks.RED_SAND) || stateBelow.is(Blocks.TERRACOTTA) || stateBelow.is(Blocks.WHITE_TERRACOTTA) || stateBelow.is(Blocks.ORANGE_TERRACOTTA) || stateBelow.is(Blocks.YELLOW_TERRACOTTA) || stateBelow.is(Blocks.BROWN_TERRACOTTA) || stateBelow.is(Blocks.DIRT))) {
+                        if (state.isAir() && (stateBelow.is(Blocks.SAND) || stateBelow.is(Blocks.RED_SAND) || stateBelow.is(Blocks.TERRACOTTA) || stateBelow.is(Blocks.DYED_TERRACOTTA.white()) || stateBelow.is(Blocks.DYED_TERRACOTTA.orange()) || stateBelow.is(Blocks.DYED_TERRACOTTA.yellow()) || stateBelow.is(Blocks.DYED_TERRACOTTA.brown()) || stateBelow.is(Blocks.DIRT))) {
                             this.placeBlock(world, Blocks.DEAD_BUSH.defaultBlockState(), x, y, z, box);
                         }
                     }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BigTunnel.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/BigTunnel.java
@@ -402,7 +402,7 @@ public class BigTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.mainShaftChestMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartChest chestMinecartEntity = EntityType.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartChest chestMinecartEntity = net.minecraft.world.entity.EntityTypes.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
                     if (chestMinecartEntity != null) {
                         chestMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         chestMinecartEntity.setLootTable(BuiltInLootTables.ABANDONED_MINESHAFT, randomSource.nextLong());
@@ -418,7 +418,7 @@ public class BigTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.mainShaftTntMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartTNT tntMinecartEntity = EntityType.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartTNT tntMinecartEntity = net.minecraft.world.entity.EntityTypes.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
                     if (tntMinecartEntity != null) {
                         tntMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         world.addFreshEntity(tntMinecartEntity);

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SideRoomDungeon.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SideRoomDungeon.java
@@ -102,7 +102,7 @@ public class SideRoomDungeon extends BetterMineshaftPiece {
         world.setBlock(spawnerPos, Blocks.SPAWNER.defaultBlockState(), 2);
         BlockEntity blockEntity = world.getBlockEntity(spawnerPos);
         if (blockEntity instanceof SpawnerBlockEntity) {
-            ((SpawnerBlockEntity) blockEntity).setEntityId(EntityType.CAVE_SPIDER, randomSource);
+            ((SpawnerBlockEntity) blockEntity).setEntityId(net.minecraft.world.entity.EntityTypes.CAVE_SPIDER, randomSource);
         }
 
         // Cobwebs immediately surrounding chests

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SmallTunnel.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/SmallTunnel.java
@@ -134,7 +134,7 @@ public class SmallTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.smallShaftChestMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartChest chestMinecartEntity = EntityType.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartChest chestMinecartEntity = net.minecraft.world.entity.EntityTypes.CHEST_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
                     if (chestMinecartEntity != null) {
                         chestMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         chestMinecartEntity.setLootTable(BuiltInLootTables.ABANDONED_MINESHAFT, randomSource.nextLong());
@@ -199,7 +199,7 @@ public class SmallTunnel extends BetterMineshaftPiece {
             if (randomSource.nextFloat() < BetterMineshaftsCommon.CONFIG.spawnRates.smallShaftTntMinecartSpawnRate) {
                 BlockPos blockPos = this.getWorldPos(LOCAL_X_END / 2, 1, z);
                 if (box.isInside(blockPos) && !world.getBlockState(blockPos.below()).isAir()) {
-                    MinecartTNT tntMinecartEntity = EntityType.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
+                    MinecartTNT tntMinecartEntity = net.minecraft.world.entity.EntityTypes.TNT_MINECART.create(world.getLevel(), EntitySpawnReason.STRUCTURE);
                     if (tntMinecartEntity != null) {
                         tntMinecartEntity.setInitialPos(blockPos.getX() + 0.5, blockPos.getY() + 0.5, blockPos.getZ() + 0.5);
                         world.addFreshEntity(tntMinecartEntity);
@@ -218,14 +218,16 @@ public class SmallTunnel extends BetterMineshaftPiece {
             if (r < BetterMineshaftsCommon.CONFIG.spawnRates.torchSpawnRate / 2) {
                 BlockPos pos = this.getWorldPos(1, 2, z);
                 BlockPos adjPos = this.getWorldPos(0, 2, z);
-                boolean canPlace = world.getBlockState(pos).isAir() && world.getBlockState(adjPos) != AIR;
+                boolean canPlace = box.isInside(pos) && box.isInside(adjPos)
+                    && world.getBlockState(pos).isAir() && world.getBlockState(adjPos) != AIR;
                 if (canPlace) {
                     this.replaceAirOrChains(world, box, 1, 2, z, 1, 2, z, torchBlock.setValue(BlockStateProperties.HORIZONTAL_FACING, Direction.EAST));
                 }
             } else if (r < BetterMineshaftsCommon.CONFIG.spawnRates.torchSpawnRate) {
                 BlockPos pos = this.getWorldPos(LOCAL_X_END - 1, 2, z);
                 BlockPos adjPos = this.getWorldPos(LOCAL_X_END, 2, z);
-                boolean canPlace = world.getBlockState(pos).isAir() && world.getBlockState(adjPos) != AIR;
+                boolean canPlace = box.isInside(pos) && box.isInside(adjPos)
+                    && world.getBlockState(pos).isAir() && world.getBlockState(adjPos) != AIR;
                 if (canPlace) {
                     this.replaceAirOrChains(world, box, LOCAL_X_END - 1, 2, z, LOCAL_X_END - 1, 2, z, torchBlock.setValue(BlockStateProperties.HORIZONTAL_FACING, Direction.WEST));
                 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/VerticalEntrance.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/VerticalEntrance.java
@@ -104,8 +104,10 @@ public class VerticalEntrance extends BetterMineshaftPiece {
         }
 
         // Only generate vertical entrance if there is valid surrounding terrain
-        if (!this.hasTunnel) {
-            determineDirection(world);
+        if (!this.hasTunnel
+            && chunkPos.x() == centerPos.getX() >> 4
+            && chunkPos.z() == centerPos.getZ() >> 4) {
+            determineDirection(world, chunkPos);
 
             if (BetterMineshaftsCommon.DEBUG_LOG && this.hasTunnel) {
                 BetterMineshaftsCommon.surfaceEntrances.add(this.centerPos.hashCode());
@@ -295,7 +297,7 @@ public class VerticalEntrance extends BetterMineshaftPiece {
      * Tries to find a direction in which there is a drop-off, with the goal of creating an opening
      * in the face of a mountain or hill.
      */
-    private void determineDirection(WorldGenLevel world) {
+    private void determineDirection(WorldGenLevel world, ChunkPos generatingChunkPos) {
         int minSurfaceHeight = world.getMaxY() - 1;
 
         // Set height for this, equal to 2 below the min height in the 5x5 vertical shaft piece
@@ -306,6 +308,9 @@ public class VerticalEntrance extends BetterMineshaftPiece {
                         realZ = centerPos.getZ() + zOffset;
                     int chunkX = realX >> 4,
                         chunkZ = realZ >> 4;
+                    if (Math.max(Math.abs(chunkX - generatingChunkPos.x()), Math.abs(chunkZ - generatingChunkPos.z())) > 1) {
+                        continue;
+                    }
                     int surfaceHeight = SurfaceHelper.getSurfaceHeight(world.getChunk(chunkX, chunkZ), new ColumnPos(realX, realZ));
                     if (surfaceHeight > 1) {
                         minSurfaceHeight = Math.min(minSurfaceHeight, surfaceHeight);
@@ -342,6 +347,12 @@ public class VerticalEntrance extends BetterMineshaftPiece {
 
                 // Check altitude of each individual block along the direction.
                 for (int i = radialDist * radius; i < radialDist * radius + radius; i++) {
+                    int chunkX = mutable.getX() >> 4;
+                    int chunkZ = mutable.getZ() >> 4;
+                    if (Math.max(Math.abs(chunkX - generatingChunkPos.x()), Math.abs(chunkZ - generatingChunkPos.z())) > 1) {
+                        mutable.move(direction);
+                        continue;
+                    }
                     int surfaceHeight = SurfaceHelper.getSurfaceHeight(world.getChunk(mutable), new ColumnPos(mutable.getX(), mutable.getZ()));
 
                     if (surfaceHeight <= floorHeight && surfaceHeight > 1) {

--- a/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/ZombieVillagerRoom.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/bettermineshafts/world/generator/pieces/ZombieVillagerRoom.java
@@ -130,17 +130,17 @@ public class ZombieVillagerRoom extends BetterMineshaftPiece {
         this.fill(world, box, 6, 2, 2, 6, 2, 4, Blocks.IRON_BARS.defaultBlockState());
 
         // Beds
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 1, 1, 4, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 1, 1, 5, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 5, 1, 4, box);
-        this.placeBlock(world, Blocks.BLACK_BED.defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 5, 1, 5, box);
+        this.placeBlock(world, Blocks.BED.black().defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 1, 1, 4, box);
+        this.placeBlock(world, Blocks.BED.black().defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 1, 1, 5, box);
+        this.placeBlock(world, Blocks.BED.black().defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.FOOT), 5, 1, 4, box);
+        this.placeBlock(world, Blocks.BED.black().defaultBlockState().setValue(BedBlock.FACING, Direction.NORTH).setValue(BedBlock.PART, BedPart.HEAD), 5, 1, 5, box);
 
         // Mob spawner
         BlockPos spawnerPos = this.getWorldPos(3, 0, 3);
         world.setBlock(spawnerPos, Blocks.SPAWNER.defaultBlockState(), 2);
         BlockEntity blockEntity = world.getBlockEntity(spawnerPos);
         if (blockEntity instanceof SpawnerBlockEntity) {
-            ((SpawnerBlockEntity) blockEntity).setEntityId(EntityType.ZOMBIE_VILLAGER, randomSource);
+            ((SpawnerBlockEntity) blockEntity).setEntityId(net.minecraft.world.entity.EntityTypes.ZOMBIE_VILLAGER, randomSource);
         }
 
         // Wall with redstone torch in corner

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=The long-awaited and much-needed abandoned mineshaft overhaul!
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.bettermineshafts
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=373591
 curseforge_project_id_neoforge=389665
 modrinth_project_id=HjmxVlSr
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.154.2
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.1
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.41-beta
+neoforge_version_range=[26.2.0.41-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.


### PR DESCRIPTION
## Summary

- update the Minecraft, Fabric, Fabric API, Cloth Config, Mod Menu, NeoForm, and NeoForge targets for Minecraft 26.2
- migrate the Minecraft 26.2 APIs and data formats used by this project
- keep the Common, Fabric, and NeoForge modules aligned with the YUNG's API 26.2 port

Depends on YUNG-GANG/YUNGs-API#109.

## Validation

- `gradlew build --no-daemon --console=plain` passes for Common, Fabric, and NeoForge on Java 25
- Fabric client and server startup were validated in a Minecraft 26.2 PrismLauncher instance
- the build was tested against the Common, Fabric, and NeoForge artifacts from the YUNG's API 26.2 port

The existing LGPL-3.0 license is preserved.
